### PR TITLE
docs: Improve README, add MIT License, and setup GitHub Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,31 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default branch, e.g., master
+  workflow_dispatch: # Allows manual triggering
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./app # Specify the folder to deploy
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Taha Tehrani Nasab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,101 @@
-# پروژه صفحه اول ایران خودرو 
+# پروژه صفحه اول ایران خودرو
 
-این پروژه یک وبسایت اصلی ایران خودرو است که با استفاده از HTML، CSS و جاوا اسکریپت ساخته شده است. 
-همچنین دو دمو درون خود دارد . در دمو اول دقریبا با اصلی فرق کم ولی دمو دوم فرق و ظاهر جدیدی دارد .
+این پروژه یک وبسایت اصلی ایران خودرو است که با استفاده از HTML، CSS و جاوا اسکریپت ساخته شده است.
+همچنین سه دمو درون خود دارد. دمو اول و سوم تفاوت کمی با نسخه اصلی دارند، اما دمو دوم ظاهر و امکانات جدیدی را ارائه می‌دهد.
 
 ## نحوه استفاده
 1. فایل‌های پروژه را در یک فولدر محلی کپی کنید.
-2. فایل index.html را در مرورگر خود باز کنید.
-3. در منو اصلی روی صفحه اصلی کلید کنید تا دمو هارا ببینید .
+2. برای مشاهده نسخه اصلی، فایل `app/index.html` را در مرورگر خود باز کنید.
+3. برای مشاهده دموها:
+    * دمو 1: فایل `app/demo1/index.html` را باز کنید.
+    * دمو 2: فایل `app/demo2/index.html` را باز کنید. این دمو شامل صفحه ورود (`login.html`) نیز می‌باشد.
+    * دمو 3: فایل `app/demo3/index.html` را باز کنید.
 
 ## ساختار پروژه
-* index.html: صفحه اصلی وبسایت
-* styles.css: استایل‌های CSS
-* script.js: کدهای جاوا اسکریپت
+* `README.md`: همین فایل راهنما.
+* `LICENSE`: فایل مجوز پروژه (به زودی اضافه خواهد شد).
+* `app/`: شامل اپلیکیشن اصلی و نسخه‌های دمو.
+    * `app/index.html`: صفحه اصلی وبسایت.
+    * `app/style.css`: استایل‌های اصلی برای `app/index.html`.
+    * `app/img/`: تصاویر مورد استفاده در صفحه اصلی.
+    * `app/demo1/`: دموی اول پروژه.
+        * `app/demo1/index.html`: صفحه اصلی دموی اول.
+        * `app/demo1/style.css`: استایل‌های مخصوص دموی اول.
+        * `app/demo1/img/`: تصاویر مورد استفاده در دموی اول.
+    * `app/demo2/`: دموی دوم پروژه با ظاهر و امکانات متفاوت.
+        * `app/demo2/index.html`: صفحه اصلی دموی دوم.
+        * `app/demo2/style.css`: استایل‌های مخصوص دموی دوم.
+        * `app/demo2/login.html`: صفحه ورود برای دموی دوم.
+        * `app/demo2/login.css`: استایل‌های صفحه ورود دموی دوم.
+        * `app/demo2/login.js`: کدهای جاوا اسکریپت برای صفحه ورود دموی دوم.
+        * `app/demo2/scripts.js`: کدهای جاوا اسکریپت اصلی برای دموی دوم.
+        * `app/demo2/img/`: تصاویر مورد استفاده در دموی دوم.
+    * `app/demo3/`: دموی سوم پروژه.
+        * `app/demo3/index.html`: صفحه اصلی دموی سوم.
+        * `app/demo3/style.css`: استایل‌های مخصوص دموی سوم.
+        * `app/demo3/img/`: تصاویر مورد استفاده در دموی سوم.
 
 ## تکنولوژی‌ها
 * HTML5
 * CSS3
-* CSS : Tailwind CSS
-* CSS : Bootstrap
+    * Tailwind CSS
+    * Bootstrap
 * JavaScript
 
 ## مجوز
-این پروژه تحت مجوز MIT منتشر شده است.
+این پروژه تحت مجوز MIT منتشر خواهد شد.
 
 ## نویسنده
-طاها تهرانی نسب 
+طاها تهرانی نسب
+
+---
+
+# Iran Khodro - Landing Page Project
+
+This project is a main website for Iran Khodro, built using HTML, CSS, and JavaScript.
+It also includes three demos. The first and third demos have minor differences from the main version, while the second demo offers a new look and features.
+
+## How to use
+1. Copy the project files to a local folder.
+2. To view the main version, open the `app/index.html` file in your browser.
+3. To view the demos:
+    * Demo 1: Open the `app/demo1/index.html` file.
+    * Demo 2: Open the `app/demo2/index.html` file. This demo also includes a login page (`login.html`).
+    * Demo 3: Open the `app/demo3/index.html` file.
+
+## Project Structure
+* `README.md`: This guide file.
+* `LICENSE`: The project license file (to be added soon).
+* `app/`: Contains the main application and demo versions.
+    * `app/index.html`: The main website landing page.
+    * `app/style.css`: Main styles for `app/index.html`.
+    * `app/img/`: Images used in the main landing page.
+    * `app/demo1/`: The first demo of the project.
+        * `app/demo1/index.html`: Main page for the first demo.
+        * `app/demo1/style.css`: Specific styles for the first demo.
+        * `app/demo1/img/`: Images used in the first demo.
+    * `app/demo2/`: The second demo of the project with a different look and features.
+        * `app/demo2/index.html`: Main page for the second demo.
+        * `app/demo2/style.css`: Specific styles for the second demo.
+        * `app/demo2/login.html`: Login page for the second demo.
+        * `app/demo2/login.css`: Styles for the login page of the second demo.
+        * `app/demo2/login.js`: JavaScript for the login page of the second demo.
+        * `app/demo2/scripts.js`: Main JavaScript for the second demo.
+        * `app/demo2/img/`: Images used in the second demo.
+    * `app/demo3/`: The third demo of the project.
+        * `app/demo3/index.html`: Main page for the third demo.
+        * `app/demo3/style.css`: Specific styles for the third demo.
+        * `app/demo3/img/`: Images used in the third demo.
+
+## Technologies
+* HTML5
+* CSS3
+    * Tailwind CSS
+    * Bootstrap
+* JavaScript
+
+## License
+This project will be released under the MIT License.
+
+## Author
+Taha Tehrani Nasab (طاها تهرانی نسب)


### PR DESCRIPTION
- Updated README.md with:
  - Persian and English versions.
  - Detailed project structure for main app and demos.
  - Clearer instructions for use.
- Added LICENSE file with standard MIT License text.
- Created `.github/workflows/gh-pages.yml` to automatically build and deploy the static content from the `/app` directory to GitHub Pages.