### PR TITLE
fix: Attempt to enable GitHub Pages via workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true # Attempt to enable Pages if not already
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Added `enablement: true` to the `configure-pages` step in the `gh-pages.yml` workflow to potentially resolve deployment issues.